### PR TITLE
Whole ZF2 does not need to be a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "zendframework/zendframework": "2.*",
+        "zendframework/zend-servicemanager": "2.*",
+        "zendframework/zend-db": "2.*",
         "stefano/stefano-nested-transaction": "0.*"
     },
     "require-dev": {


### PR DESCRIPTION
Improves tests speed (also for dependent packages)
